### PR TITLE
Fix toggle state logic

### DIFF
--- a/iron-button-state.html
+++ b/iron-button-state.html
@@ -72,7 +72,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        // a tap is needed to toggle the active state
         this._userActivate(!this.active);
       } else {
-        this.active = false;
+        // if the element cannot be toggled, then it cannot be deactivated once
+        // it has been tapped and activated
+        this.active = true;
       }
     },
 


### PR DESCRIPTION
I think the old logic was wrong, and basically never activated an item with `toggles=false`. The idea is that if `toggles=false`, once you get activated, you stay activated, which means `active=true` henceforth.