### PR TITLE
Correct a type error found by the JSCompiler.

### DIFF
--- a/iron-control-state.html
+++ b/iron-control-state.html
@@ -46,7 +46,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       _oldTabIndex: {
-        type: String
+        type: Number
       }
     },
 


### PR DESCRIPTION
Element.prototype.tabindex is actually a number, not a string.