### PR TITLE
Force buttons to lose visual focus after pressed

### DIFF
--- a/iron-button-state.html
+++ b/iron-button-state.html
@@ -96,6 +96,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     _upHandler: function(e) {
       this._setPressed(false);
+      this._setFocused(false);
     },
 
     _spaceKeyUpHandler: function(e) {


### PR DESCRIPTION
**material design spec audit https://github.com/PolymerElements/paper-button/issues/12**

* Decision handed down from design: button should NOT stay focused after press, unless it was focused prior to press.

cc @morethanreal @notwaldorf 