### PR TITLE
Differentiate mouse from keyboard focus and preserve `active` state

### DIFF
--- a/iron-button-state.html
+++ b/iron-button-state.html
@@ -129,7 +129,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _controlStateChanged: function() {
       if (this.disabled) {
         this._setPressed(false);
-        this.active = false;
       } else {
         this._changedButtonState();
       }

--- a/iron-button-state.html
+++ b/iron-button-state.html
@@ -92,6 +92,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     _downHandler: function() {
       this._setPressed(true);
+      this._setFocused(true);
     },
 
     _upHandler: function(e) {


### PR DESCRIPTION
This will fix https://github.com/PolymerElements/iron-behaviors/issues/8   and https://github.com/PolymerElements/iron-behaviors/issues/9


It will also help to solve https://github.com/PolymerElements/paper-radio-button/issues/18

cc @cdata @morethanreal @notwaldorf 