### PR TITLE
Prevent default on space keydown.

### DIFF
--- a/iron-button-state.html
+++ b/iron-button-state.html
@@ -126,12 +126,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this._setReceivedFocusFromKeyboard(false);
     },
 
-    _upHandler: function(e) {
+    _upHandler: function() {
       this._setPointerDown(false);
       this._setPressed(false);
     },
 
-    _spaceKeyDownHandler: function() {
+    _spaceKeyDownHandler: function(event) {
+      var keyboardEvent = event.detail.keyboardEvent;
+      keyboardEvent.preventDefault();
+      keyboardEvent.stopImmediatePropagation();
       this._setPressed(true);
     },
 


### PR DESCRIPTION
This keeps the page from scrolling down in some browsers.