### PR TITLE
allow overriding of the aria-pressed attribute

### DIFF
--- a/iron-button-state.html
+++ b/iron-button-state.html
@@ -50,8 +50,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         type: Boolean,
         value: false,
         notify: true,
-        reflectToAttribute: true,
-        observer: '_activeChanged'
+        reflectToAttribute: true
       },
 
       /**
@@ -72,6 +71,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       receivedFocusFromKeyboard: {
         type: Boolean,
         readOnly: true
+      },
+
+      /**
+       * The aria attribute to be set if the button is a toggle and in the
+       * active state.
+       */
+      ariaActiveAttribute: {
+        type: String,
+        value: 'aria-pressed',
+        observer: '_ariaActiveAttributeChanged'
       }
     },
 
@@ -82,7 +91,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     observers: [
-      '_detectKeyboardFocus(focused)'
+      '_detectKeyboardFocus(focused)',
+      '_activeChanged(active, ariaActiveAttribute)'
     ],
 
     keyBindings: {
@@ -150,11 +160,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this._changedButtonState();
     },
 
-    _activeChanged: function(active) {
+    _ariaActiveAttributeChanged: function(value, oldValue) {
+      if (oldValue && oldValue != value && this.hasAttribute(oldValue)) {
+        this.removeAttribute(oldValue);
+      }
+    },
+
+    _activeChanged: function(active, ariaActiveAttribute) {
       if (this.toggles) {
-        this.setAttribute('aria-pressed', active ? 'true' : 'false');
+        this.setAttribute(this.ariaActiveAttribute,
+                          active ? 'true' : 'false');
       } else {
-        this.removeAttribute('aria-pressed');
+        this.removeAttribute(this.ariaActiveAttribute);
       }
       this._changedButtonState();
     },

--- a/test/active-state.html
+++ b/test/active-state.html
@@ -51,6 +51,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             MockInteractions.downAndUp(activeTarget, function() {
               try {
                 expect(activeTarget.hasAttribute('active')).to.be.eql(true);
+                expect(activeTarget.hasAttribute('aria-pressed')).to.be.eql(true);
+                expect(activeTarget.getAttribute('aria-pressed')).to.be.eql('true');
                 done();
               } catch (e) {
                 done(e);
@@ -63,11 +65,46 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               MockInteractions.downAndUp(activeTarget, function() {
                 try {
                   expect(activeTarget.hasAttribute('active')).to.be.eql(false);
+                  expect(activeTarget.hasAttribute('aria-pressed')).to.be.eql(true);
+                  expect(activeTarget.getAttribute('aria-pressed')).to.be.eql('false');
                   done();
                 } catch (e) {
                   done(e);
                 }
               });
+            });
+          });
+
+          test('the correct aria attribute is set', function(done) {
+            activeTarget.ariaActiveAttribute = 'aria-checked';
+            MockInteractions.downAndUp(activeTarget, function() {
+              try {
+                expect(activeTarget.hasAttribute('active')).to.be.eql(true);
+                expect(activeTarget.hasAttribute('aria-checked')).to.be.eql(true);
+                expect(activeTarget.getAttribute('aria-checked')).to.be.eql('true');
+                done();
+              } catch (e) {
+                done(e);
+              }
+            });
+          });
+
+          test('the aria attribute is updated correctly', function(done) {
+            activeTarget.ariaActiveAttribute = 'aria-checked';
+            MockInteractions.downAndUp(activeTarget, function() {
+              try {
+                expect(activeTarget.hasAttribute('active')).to.be.eql(true);
+                expect(activeTarget.hasAttribute('aria-checked')).to.be.eql(true);
+                expect(activeTarget.getAttribute('aria-checked')).to.be.eql('true');
+
+                activeTarget.ariaActiveAttribute = 'aria-pressed';
+                expect(activeTarget.hasAttribute('aria-checked')).to.be.eql(false);
+                expect(activeTarget.hasAttribute('aria-pressed')).to.be.eql(true);
+                expect(activeTarget.getAttribute('aria-pressed')).to.be.eql('true');
+                done();
+              } catch (e) {
+                done(e);
+              }
             });
           });
         });


### PR DESCRIPTION
This would allow elements like `paper checkbox` to set `aria-checked` instead (see https://github.com/PolymerElements/paper-checkbox/issues/44)