### PR TITLE
Don't fire unnecessary change events

### DIFF
--- a/iron-button-state.html
+++ b/iron-button-state.html
@@ -107,8 +107,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     // to emulate native checkbox, (de-)activations from a user interaction fire
     // 'change' events
     _userActivate: function(active) {
-      this.active = active;
-      this.fire('change');
+      if (this.active !== active) {
+        this.active = active;
+        this.fire('change');
+      }
     },
 
     _downHandler: function() {


### PR DESCRIPTION
Especially with paper-toggle-button, change events were thrown on every mouse move while dragging, even when it didn't change anything.