### PR TITLE
Revert ShadowDOM faulty retargeting approximation.

### DIFF
--- a/iron-control-state.html
+++ b/iron-control-state.html
@@ -60,11 +60,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     ],
 
     ready: function() {
-      // TODO(sjmiles): ensure read-only property is valued so the compound
-      // observer will fire
-      if (this.focused === undefined) {
-        this._setFocused(false);
-      }
       this.addEventListener('focus', this._boundFocusBlurHandler, true);
       this.addEventListener('blur', this._boundFocusBlurHandler, true);
     },
@@ -75,7 +70,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var focused = event.type === 'focus';
         this._setFocused(focused);
       } else if (!this.shadowRoot) {
-        event.stopPropagation();
         this.fire(event.type, {sourceEvent: event}, {
           node: this,
           bubbles: event.bubbles,

--- a/test/focused-state.html
+++ b/test/focused-state.html
@@ -90,26 +90,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         focusable = fixture('NestedFocusedState');
       });
 
-      test('focus/blur events fired on host element', function(done) {
+      test('focus/blur events fired on host element', function() {
         var nFocusEvents = 0;
         var nBlurEvents = 0;
+
         focusable.addEventListener('focus', function() {
           nFocusEvents += 1;
-          // setTimeout to wait for potentially more, erroneous events
-          setTimeout(function() {
-            assert.equal(nFocusEvents, 1, 'one focus event fired');
-            MockInteractions.blur(focusable.$.input);
-          });
+          MockInteractions.blur(focusable.$.input);
         });
         focusable.addEventListener('blur', function() {
           nBlurEvents += 1;
-          // setTimeout to wait for potentially more, erroneous events
-          setTimeout(function() {
-            assert.equal(nBlurEvents, 1, 'one blur event fired');
-            done();
-          });
         });
+
         MockInteractions.focus(focusable.$.input);
+
+        expect(nBlurEvents).to.be.greaterThan(0);
+        expect(nFocusEvents).to.be.greaterThan(0);
       });
 
     });


### PR DESCRIPTION
Do not stop propagation of focus and blur events when retargeting.

/cc @notwaldorf 