### PR TITLE
Set `aria-disabled` when a role was set`

### DIFF
--- a/iron-control-state.html
+++ b/iron-control-state.html
@@ -84,7 +84,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     _disabledChanged: function(disabled, old) {
-      this.setAttribute('aria-disabled', disabled ? 'true' : 'false');
+      // set the `aria-disabled` attribute only when a `role` was set.
+      if (this.hasAttribute('role')) {
+        this.setAttribute('aria-disabled', disabled ? 'true' : 'false');
+      }
       this.style.pointerEvents = disabled ? 'none' : '';
       if (disabled) {
         this._oldTabIndex = this.tabIndex;

--- a/test/disabled-state.html
+++ b/test/disabled-state.html
@@ -29,7 +29,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <test-fixture id="InitiallyDisabledState">
     <template>
-      <test-control disabled></test-control>
+      <test-control role="slider" disabled></test-control>
     </template>
   </test-fixture>
 
@@ -48,9 +48,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             expect(disableTarget.hasAttribute('disabled')).to.be.eql(true);
           });
 
-          test('receives an appropriate aria attribute', function() {
+          test('sets aria-disabled when a role is set', function() {
+            expect(disableTarget.getAttribute('aria-disabled')).to.be.null;
             disableTarget.disabled = true;
-            expect(disableTarget.getAttribute('aria-disabled')).to.be.eql('true');
+            expect(disableTarget.getAttribute('aria-disabled')).to.be.null;
+
+            disableTarget.setAttribute('role', 'dialog');
+            disableTarget.disabled = false;
+            expect(disableTarget.getAttribute('aria-disabled')).to.be.eql('false');
           });
         });
 


### PR DESCRIPTION
According to the spec, `aria-disabled` should be used in combination with a role. I have moved the role in paper-slider from the host to a children to allow navigation from the slider to the input when it's in editable mode.

ref: http://www.w3.org/TR/wai-aria/states_and_properties#aria-disabled
https://github.com/PolymerElements/paper-slider/pull/58

cc @notwaldorf 