### PR TITLE
fix nested input event handling

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -30,7 +30,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 </head>
 <body>
-
   <div class="vertical-section vertical-section-container centered">
     <h3>Normal</h3>
 

--- a/iron-button-state.html
+++ b/iron-button-state.html
@@ -136,11 +136,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this._setPressed(false);
     },
 
+    __isFocusedLightDescendant: function(target) {
+      var root = Polymer.dom(this).getOwnerRoot() || document;
+      var focusedElement = root.activeElement;
+
+      // TODO(noms): remove the `this !== target` check once polymer#2610 is fixed.
+      return this !== target && this.isLightDescendant(target) && target == focusedElement;
+    },
+
     /**
      * @param {!KeyboardEvent} event .
-     */ 
+     */
     _spaceKeyDownHandler: function(event) {
       var keyboardEvent = event.detail.keyboardEvent;
+      var target = Polymer.dom(keyboardEvent).localTarget;
+
+      // Ignore the event if this is coming from a focused light child, since that
+      // element will deal with it.
+      if (this.__isFocusedLightDescendant(target))
+        return;
+
       keyboardEvent.preventDefault();
       keyboardEvent.stopImmediatePropagation();
       this._setPressed(true);
@@ -148,8 +163,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     /**
      * @param {!KeyboardEvent} event .
-     */ 
+     */
     _spaceKeyUpHandler: function(event) {
+      var keyboardEvent = event.detail.keyboardEvent;
+      var target = Polymer.dom(keyboardEvent).localTarget;
+
+      // Ignore the event if this is coming from a focused light child, since that
+      // element will deal with it.
+      if (this.__isFocusedLightDescendant(target))
+        return;
+
       if (this.pressed) {
         this._asyncClick();
       }

--- a/test/active-state.html
+++ b/test/active-state.html
@@ -33,6 +33,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="ButtonWithInput">
+    <template>
+      <test-light-dom><input id="input"></test-light-dom>
+    </template>
+  </test-fixture>
+
   <script>
     suite('active-state', function() {
       var activeTarget;
@@ -192,6 +198,39 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           MockInteractions.pressEnter(activeTarget);
         });
       });
+
+      suite('nested input inside button', function() {
+        test('space in light child input does not trigger a button click event', function(done) {
+          var item = fixture('ButtonWithInput');
+          var input = item.querySelector('#input');
+
+          var itemClickHandler = sinon.spy();
+          item.addEventListener('click', itemClickHandler);
+
+          input.focus();
+          MockInteractions.pressSpace(input);
+          setTimeout(function(){
+            expect(itemClickHandler.callCount).to.be.equal(0);
+            done();
+          }, 100);
+        });
+
+        test('space in button triggers a button click event', function(done) {
+          var item = fixture('ButtonWithInput');
+          var input = item.querySelector('#input');
+
+          var itemClickHandler = sinon.spy();
+          item.addEventListener('click', itemClickHandler);
+
+          MockInteractions.pressSpace(item);
+
+          setTimeout(function(){
+            expect(itemClickHandler.callCount).to.be.equal(1);
+            done();
+          }, 100);
+        });
+      });
+
     });
   </script>
 </body>

--- a/test/test-elements.html
+++ b/test/test-elements.html
@@ -80,7 +80,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     is: 'test-light-dom',
 
     behaviors: [
-      Polymer.IronControlState
+      Polymer.IronControlState,
+      Polymer.IronButtonState
     ]
 
   });


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-item/issues/28, or more generically, the "`<input>` inside a `<button>`" kind of scenario.

Problem: if you have an `input` inside a `button`, the `input` should deal with any keys coming to it, not the `button` (otherwise, in the simplest case, you can't type spaces inside the `input` because it registers as an activation event for the outer `button`)

