### PR TITLE
Annotate event params

### DIFF
--- a/iron-button-state.html
+++ b/iron-button-state.html
@@ -136,6 +136,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this._setPressed(false);
     },
 
+    /**
+     * @param {!KeyboardEvent} event .
+     */ 
     _spaceKeyDownHandler: function(event) {
       var keyboardEvent = event.detail.keyboardEvent;
       keyboardEvent.preventDefault();
@@ -143,7 +146,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this._setPressed(true);
     },
 
-    _spaceKeyUpHandler: function() {
+    /**
+     * @param {!KeyboardEvent} event .
+     */ 
+    _spaceKeyUpHandler: function(event) {
       if (this.pressed) {
         this._asyncClick();
       }


### PR DESCRIPTION
This isn't strictly necessary, except that paper-button-behavior calls these functions and passes in the event, but `_spaceKeyUpHandler` didn't take an arg before, so compiler was suspicious :dog: