### PR TITLE
remove activeElement check from the space handler code

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,15 +16,16 @@
   ],
   "license": "http://polymer.github.io/LICENSE.txt",
   "dependencies": {
-    "polymer": "Polymer/polymer#^1.0.0",
+    "polymer": "Polymer/polymer#^1.2.0",
     "iron-a11y-keys-behavior": "PolymerElements/iron-a11y-keys-behavior#^1.0.0"
   },
   "devDependencies": {
     "paper-styles": "polymerelements/paper-styles#^1.0.2",
+    "paper-input": "polymerelements/paper-input#^1.0.0",
     "iron-test-helpers": "polymerelements/iron-test-helpers#^1.0.0",
     "iron-component-page": "polymerelements/iron-component-page#^1.0.0",
     "test-fixture": "polymerelements/test-fixture#^1.0.0",
-    "web-component-tester": "*",
+    "web-component-tester": "polymer/web-component-tester#^3.4.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
   },
   "ignore": []

--- a/iron-button-state.html
+++ b/iron-button-state.html
@@ -136,14 +136,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this._setPressed(false);
     },
 
-    __isFocusedLightDescendant: function(target) {
-      var root = Polymer.dom(this).getOwnerRoot() || document;
-      var focusedElement = root.activeElement;
-
-      // TODO(noms): remove the `this !== target` check once polymer#2610 is fixed.
-      return this !== target && this.isLightDescendant(target) && target == focusedElement;
-    },
-
     /**
      * @param {!KeyboardEvent} event .
      */
@@ -153,7 +145,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       // Ignore the event if this is coming from a focused light child, since that
       // element will deal with it.
-      if (this.__isFocusedLightDescendant(target))
+      if (this.isLightDescendant(target))
         return;
 
       keyboardEvent.preventDefault();
@@ -170,7 +162,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       // Ignore the event if this is coming from a focused light child, since that
       // element will deal with it.
-      if (this.__isFocusedLightDescendant(target))
+      if (this.isLightDescendant(target))
         return;
 
       if (this.pressed) {

--- a/test/active-state.html
+++ b/test/active-state.html
@@ -13,12 +13,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
-  <script src="../../test-fixture/test-fixture-mocha.js"></script>
   <script src="../../iron-test-helpers/mock-interactions.js"></script>
-
-  <link rel="import" href="../../polymer/polymer.html">
-  <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="test-elements.html">
+  <link rel="import" href="../../paper-input/paper-input.html">
 </head>
 <body>
   <test-fixture id="TrivialActiveState">
@@ -33,9 +30,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
-  <test-fixture id="ButtonWithInput">
+  <test-fixture id="ButtonWithNativeInput">
     <template>
       <test-light-dom><input id="input"></test-light-dom>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="ButtonWithPaperInput">
+    <template>
+      <test-light-dom><paper-input id="input"></paper-input></test-light-dom>
     </template>
   </test-fixture>
 
@@ -199,9 +202,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       });
 
-      suite('nested input inside button', function() {
+      suite('nested native input inside button', function() {
         test('space in light child input does not trigger a button click event', function(done) {
-          var item = fixture('ButtonWithInput');
+          var item = fixture('ButtonWithNativeInput');
           var input = item.querySelector('#input');
 
           var itemClickHandler = sinon.spy();
@@ -209,14 +212,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           input.focus();
           MockInteractions.pressSpace(input);
-          setTimeout(function(){
+          Polymer.Base.async(function(){
             expect(itemClickHandler.callCount).to.be.equal(0);
             done();
-          }, 100);
+          }, 1);
         });
 
         test('space in button triggers a button click event', function(done) {
-          var item = fixture('ButtonWithInput');
+          var item = fixture('ButtonWithNativeInput');
           var input = item.querySelector('#input');
 
           var itemClickHandler = sinon.spy();
@@ -224,10 +227,49 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           MockInteractions.pressSpace(item);
 
-          setTimeout(function(){
-            expect(itemClickHandler.callCount).to.be.equal(1);
+          Polymer.Base.async(function(){
+            // You need two ticks, one for the MockInteractions event, and one
+            // for the button event.
+            Polymer.Base.async(function(){
+              expect(itemClickHandler.callCount).to.be.equal(1);
+              done();
+            }, 1);
+          }, 1);
+        });
+      });
+
+      suite('nested paper-input inside button', function() {
+        test('space in light child input does not trigger a button click event', function(done) {
+          var item = fixture('ButtonWithPaperInput');
+          var input = item.querySelector('#input');
+
+          var itemClickHandler = sinon.spy();
+          item.addEventListener('click', itemClickHandler);
+
+          input.focus();
+          MockInteractions.pressSpace(input);
+          Polymer.Base.async(function(){
+            expect(itemClickHandler.callCount).to.be.equal(0);
             done();
-          }, 100);
+          }, 1);
+        });
+
+        test('space in button triggers a button click event', function(done) {
+          var item = fixture('ButtonWithPaperInput');
+          var input = item.querySelector('#input');
+
+          var itemClickHandler = sinon.spy();
+          item.addEventListener('click', itemClickHandler);
+
+          MockInteractions.pressSpace(item);
+          Polymer.Base.async(function(){
+            // You need two ticks, one for the MockInteractions event, and one
+            // for the button event.
+            Polymer.Base.async(function(){
+              expect(itemClickHandler.callCount).to.be.equal(1);
+              done();
+            }, 1);
+          }, 1);
         });
       });
 

--- a/test/disabled-state.html
+++ b/test/disabled-state.html
@@ -13,10 +13,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
-  <script src="../../test-fixture/test-fixture-mocha.js"></script>
-
-  <link rel="import" href="../../polymer/polymer.html">
-  <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="test-elements.html">
 </head>
 <body>

--- a/test/focused-state.html
+++ b/test/focused-state.html
@@ -13,11 +13,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
-  <script src="../../test-fixture/test-fixture-mocha.js"></script>
   <script src="../../iron-test-helpers/mock-interactions.js"></script>
-
-  <link rel="import" href="../../polymer/polymer.html">
-  <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="test-elements.html">
 </head>
 <body>
@@ -135,12 +131,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         lightDOM.addEventListener('focus', function() {
           nFocusEvents += 1;
         });
-        
+
         MockInteractions.focus(input);
 
         expect(nFocusEvents).to.be.equal(0);
       });
-      
+
     });
 
   </script>

--- a/test/test-elements.html
+++ b/test/test-elements.html
@@ -7,6 +7,7 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 
+<link rel="import" href="../../polymer/polymer.html">
 <link rel="import" href="../iron-control-state.html">
 <link rel="import" href="../iron-button-state.html">
 


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-item/issues/28 again.

The problem is that if you have a native `<input>` inside a clickable thing, then `activeElement` will return the correct thing. If you have have a custom element like a `<paper-input>` inside a clickable thing, then `activeElement` in the shady DOM returns the wrong thing (in this case, the nested `<input>` that's actually focused). For custom elements we could add a check for `focused`, but this isn't available for native elements, so this is all more trouble than it's worth. If you somehow generate a synthetic click from a nested, non-focused element, that's your foot gun.

Bumped `polymer`'s version because that's where `isLightDescendant` lives, bumped `wct` and did the `test-fixture` cleanup. 🍬🍬🍬 