### PR TITLE
Prevent retargeting of events from shadow descendants of light children.

### DIFF
--- a/iron-control-state.html
+++ b/iron-control-state.html
@@ -73,7 +73,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       if (event.target === this) {
         this._setFocused(event.type === 'focus');
-      } else if (!this.shadowRoot && !this.isLightDescendant(event.target)) {
+      } else if (!this.shadowRoot &&
+          !this.isLightDescendant(Polymer.dom(event).localTarget)) {
         this.fire(event.type, {sourceEvent: event}, {
           node: this,
           bubbles: event.bubbles,

--- a/test/focused-state.html
+++ b/test/focused-state.html
@@ -31,10 +31,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
-   <test-fixture id="LightDOM">
+  <test-fixture id="LightDOM">
     <template>
       <test-light-dom>
         <input id="input">
+        <nested-focusable></nested-focusable>
       </test-light-dom>
     </template>
   </test-fixture>
@@ -119,11 +120,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 
     suite('elements in the light dom', function() {
-      var lightDOM, input;
+      var lightDOM, input, lightDescendantShadowInput;
 
       setup(function() {
         lightDOM = fixture('LightDOM');
         input = document.querySelector('#input');
+        lightDescendantShadowInput = Polymer.dom(lightDOM)
+            .querySelector('nested-focusable').$.input;
       });
 
       test('should not fire the focus event', function() {
@@ -134,6 +137,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         MockInteractions.focus(input);
+
+        expect(nFocusEvents).to.be.equal(0);
+      });
+
+      test('should not fire the focus event from shadow descendants', function() {
+        var nFocusEvents = 0;
+
+        lightDOM.addEventListener('focus', function() {
+          nFocusEvents += 1;
+        });
+
+        MockInteractions.focus(lightDescendantShadowInput);
 
         expect(nFocusEvents).to.be.equal(0);
       });


### PR DESCRIPTION
(fixes PolymerElements/paper-menu#89)