### PR TITLE
Check type of event target

### DIFF
--- a/iron-control-state.html
+++ b/iron-control-state.html
@@ -73,13 +73,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       if (event.target === this) {
         this._setFocused(event.type === 'focus');
-      } else if (!this.shadowRoot &&
-          !this.isLightDescendant(Polymer.dom(event).localTarget)) {
-        this.fire(event.type, {sourceEvent: event}, {
-          node: this,
-          bubbles: event.bubbles,
-          cancelable: event.cancelable
-        });
+      } else if (!this.shadowRoot) {
+        var target = /** @type {Node} */(Polymer.dom(event).localTarget);
+        if (!this.isLightDescendant(target)) {
+          this.fire(event.type, {sourceEvent: event}, {
+            node: this,
+            bubbles: event.bubbles,
+            cancelable: event.cancelable
+          });
+        }
       }
     },
 


### PR DESCRIPTION
This fixes an error in Closure (found: `EventTarget`, required: `Node|null`).

I think it theoretically fixes a bug if something other than a Node is the target, although not sure if thath's possible with the `focus` event without trying really hard to break something.