### PR TITLE
Refocusing window restores previous keyboard-focused state

### DIFF
--- a/iron-button-state.html
+++ b/iron-button-state.html
@@ -13,6 +13,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="iron-control-state.html">
 
 <script>
+(function () {
+
+  var processingWindowFocusEvent = false;
+  var lastKeyboardFocusedElement;
 
   /**
    * @demo demo/index.html
@@ -112,10 +116,31 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     },
 
+    // Heuristically determine whether this element received the focus via
+    // the keyboard. In most situations, we infer that, if the pointer isn't
+    // currently down, then the user must have moved the focus with the
+    // keyboard.
     _detectKeyboardFocus: function(focused) {
-      console.log(this.textContent.trim() + ' detectKeyboardFocus: ' + focused + ' ' + this.pointerDown + ' ' + this.receivedFocusViaWindowRestore);
-      if (focused && !this.receivedFocusViaWindowRestore) {
-        this._setReceivedFocusFromKeyboard(!this.pointerDown);
+      if (focused) {
+        // One special case is when the user is moving focus back to the current
+        // window. When a window blurs, the active element will blur too. If the
+        // user later restores focus to the window, the element will get a focus
+        // event again. If that element had previously been focused with the
+        // keyboard, we want to reestablish its receivedFocusFromKeyboard flag.
+        // This allows a keyboard user to once again see where the focus is
+        // without having to begin tabbing around.
+        var keyboard = processingWindowFocusEvent ?
+          (this === lastKeyboardFocusedElement) : // Keyboard used originally
+          !this.pointerDown;                      // Keyboard in use right now
+
+        this._setReceivedFocusFromKeyboard(keyboard);
+
+        // If the keyboard was used, remember this element so that, if the
+        // window suddenly loses and then regains focus, we can tell whether to
+        // reestablish the keyboard flag (above).
+        lastKeyboardFocusedElement = keyboard ? this : null;
+      } else {
+        this._setReceivedFocusFromKeyboard(false);
       }
     },
 
@@ -132,6 +157,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this._setPointerDown(true);
       this._setPressed(true);
       this._setReceivedFocusFromKeyboard(false);
+      lastKeyboardFocusedElement = null;
     },
 
     _upHandler: function() {
@@ -228,4 +254,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     Polymer.IronButtonStateImpl
   ];
 
+  /*
+   * Set a flag we can use to detect when an element is receiving a focus event
+   * because the window has been refocused.
+   */
+  window.addEventListener('focus', function(event) {
+    // This point is reached before the element that will regain the focus will
+    // receive its focus event.
+    processingWindowFocusEvent = true;
+    setTimeout(function() {
+      // If an element has regained the focus, this point will be reached after
+      // that element's focus event.
+      processingWindowFocusEvent = false;
+    });
+  });
+
+})();
 </script>

--- a/iron-button-state.html
+++ b/iron-button-state.html
@@ -100,7 +100,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     ],
 
     keyBindings: {
-      'enter:keydown': '_asyncClick',
+      'enter:keydown': '_enterKeyDownHandler',
       'space:keydown': '_spaceKeyDownHandler',
       'space:keyup': '_spaceKeyUpHandler',
     },
@@ -132,14 +132,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var keyboard = processingWindowFocusEvent ?
           (this === lastKeyboardFocusedElement) : // Keyboard used originally
           !this.pointerDown;                      // Keyboard in use right now
-
-        this._setReceivedFocusFromKeyboard(keyboard);
-
-        // If the keyboard was used, remember this element so that, if the
-        // window suddenly loses and then regains focus, we can tell whether to
-        // reestablish the keyboard flag (above).
-        lastKeyboardFocusedElement = keyboard ? this : null;
+        this._trackKeyboardFocusedElement(keyboard);
       } else {
+        // Update this element's keyboard focus state. Since the element's
+        // losing focus, not gaining it, we don't update our notion of which
+        // element last received focus via the keyboard.
         this._setReceivedFocusFromKeyboard(false);
       }
     },
@@ -156,13 +153,29 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _downHandler: function(event) {
       this._setPointerDown(true);
       this._setPressed(true);
-      this._setReceivedFocusFromKeyboard(false);
-      lastKeyboardFocusedElement = null;
+      this._trackKeyboardFocusedElement(false);
     },
 
     _upHandler: function() {
       this._setPointerDown(false);
       this._setPressed(false);
+    },
+
+    _trackKeyboardFocusedElement: function(receivedFocusFromKeyboard) {
+      this._setReceivedFocusFromKeyboard(receivedFocusFromKeyboard);
+
+      // If the keyboard was used, remember this element so that, if the
+      // window suddenly loses and then regains focus, we can tell whether to
+      // reestablish the keyboard flag in _detectKeyboardFocus.
+      lastKeyboardFocusedElement = receivedFocusFromKeyboard ? this : null;
+    },
+
+    /**
+     * @param {!KeyboardEvent} event .
+     */
+    _enterKeyDownHandler: function(event) {
+      this._trackKeyboardFocusedElement(true);
+      this._asyncClick();
     },
 
     /**
@@ -179,6 +192,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       keyboardEvent.preventDefault();
       keyboardEvent.stopImmediatePropagation();
+      this._trackKeyboardFocusedElement(true);
       this._setPressed(true);
     },
 

--- a/iron-button-state.html
+++ b/iron-button-state.html
@@ -113,7 +113,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     _detectKeyboardFocus: function(focused) {
-      this._setReceivedFocusFromKeyboard(!this.pointerDown && focused);
+      console.log(this.textContent.trim() + ' detectKeyboardFocus: ' + focused + ' ' + this.pointerDown + ' ' + this.receivedFocusViaWindowRestore);
+      if (focused && !this.receivedFocusViaWindowRestore) {
+        this._setReceivedFocusFromKeyboard(!this.pointerDown);
+      }
     },
 
     // to emulate native checkbox, (de-)activations from a user interaction fire

--- a/iron-control-state.html
+++ b/iron-control-state.html
@@ -11,6 +11,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../polymer/polymer.html">
 
 <script>
+function documentFocusListener(event) {
+  console.log('element focus');
+  event._focusRestoredToWindow = true;
+  document.removeEventListener('focus', documentFocusListener);
+}
+window.addEventListener('focus', function(event) {
+  console.log('window focus');
+  setTimeout(function() {
+    console.log('window focus timeout');
+  });
+});
+window.addEventListener('blur', function(event) {
+  console.log('window blur');
+  document.addEventListener('focus', documentFocusListener, true);
+});
 
   /**
    * @demo demo/index.html
@@ -40,6 +55,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         notify: true,
         observer: '_disabledChanged',
         reflectToAttribute: true
+      },
+
+      /**
+       * True if the action that caused the element to receive focus was the
+       * top-level tab/window having focused restored to it.
+       */
+      receivedFocusViaWindowRestore: {
+        type: Boolean,
+        readOnly: true
       },
 
       _oldTabIndex: {
@@ -72,7 +96,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // handled). In either case, we can disregard `event.path`.
 
       if (event.target === this) {
-        this._setFocused(event.type === 'focus');
+        console.log(this.textContent.trim() + ' ' + event.type + ' ' + event._focusRestoredToWindow);
+        var focused = (event.type === 'focus');
+        this._setReceivedFocusViaWindowRestore(event._focusRestoredToWindow || false);
+        this._setFocused(focused);
       } else if (!this.shadowRoot) {
         var target = /** @type {Node} */(Polymer.dom(event).localTarget);
         if (!this.isLightDescendant(target)) {

--- a/iron-control-state.html
+++ b/iron-control-state.html
@@ -11,21 +11,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../polymer/polymer.html">
 
 <script>
-function documentFocusListener(event) {
-  console.log('element focus');
-  event._focusRestoredToWindow = true;
-  document.removeEventListener('focus', documentFocusListener);
-}
-window.addEventListener('focus', function(event) {
-  console.log('window focus');
-  setTimeout(function() {
-    console.log('window focus timeout');
-  });
-});
-window.addEventListener('blur', function(event) {
-  console.log('window blur');
-  document.addEventListener('focus', documentFocusListener, true);
-});
 
   /**
    * @demo demo/index.html
@@ -55,15 +40,6 @@ window.addEventListener('blur', function(event) {
         notify: true,
         observer: '_disabledChanged',
         reflectToAttribute: true
-      },
-
-      /**
-       * True if the action that caused the element to receive focus was the
-       * top-level tab/window having focused restored to it.
-       */
-      receivedFocusViaWindowRestore: {
-        type: Boolean,
-        readOnly: true
       },
 
       _oldTabIndex: {
@@ -96,10 +72,7 @@ window.addEventListener('blur', function(event) {
       // handled). In either case, we can disregard `event.path`.
 
       if (event.target === this) {
-        console.log(this.textContent.trim() + ' ' + event.type + ' ' + event._focusRestoredToWindow);
-        var focused = (event.type === 'focus');
-        this._setReceivedFocusViaWindowRestore(event._focusRestoredToWindow || false);
-        this._setFocused(focused);
+        this._setFocused(event.type === 'focus');
       } else if (!this.shadowRoot) {
         var target = /** @type {Node} */(Polymer.dom(event).localTarget);
         if (!this.isLightDescendant(target)) {


### PR DESCRIPTION
Initial PR, but do not merge yet — there's an open question about unit tests below.

This is a proposed fix for PolymerElements/paper-button#24.

To summarize what I believe is the desired behavior:
* Material Design wants to render focused buttons differently depending on whether they received the focus via the keyboard or a pointer.
* When a window loses the focus, the focused element should drop its focused appearance — but if the window regains the focus, the previously-focused element regain its earlier, specific keyboard/pointer focus rendering.

It seems that all buttons should exhibit this behavior, not just `paper-button`, so this PR proposes making the fix in iron-button-state. (If that seems correct, I can move the issue to iron-button-state.)

The PR fixes the issue by:
1. Tracking whether the last element to receive the focus had gotten the focus via the keyboard.
2. Detecting whether we're currently doing work in response to a window having been restored.
3. In the case where the window is being restored (point 2, above), we look to see whether the element getting the focus was previously focused via the keyboard (point 1, above). If so, we restore its keyboard-focused appearance; otherwise, we let it render with the pointer-focused appearance.

This PR opportunistically fixes a related, subtle bug in keyboard/pointer focus rendering: if the user switches input modalities while a button has focus, the button's keyboard/pointer focus rendering updates to match the latest modality. If the user presses down on a button with a pointer, then press Space or Enter, the keyboard focus rendering is applied. Conversely, if the user tabs to a button with the keyboard, but then presses the button with a pointer, the keyboard rendering is dropped.

At this point, the core functionality appears to work in interactive testing of paper-button, paper-checkbox, and paper-radio-button, but I'd like recommendations on unit testing this. All existing unit tests pass, but the PR does not yet include unit tests for the new behavior. The new behavior is implicated in window-level blur/focus events, which are not possible to directly test in unit tests, nor does there appear to be support for mock window blur/focus events.