### PR TITLE
Button should not stay pressed when it becomes unfocused

### DIFF
--- a/iron-button-state.html
+++ b/iron-button-state.html
@@ -91,7 +91,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     observers: [
-      '_detectKeyboardFocus(focused)',
+      '_focusChanged(focused)',
       '_activeChanged(active, ariaActiveAttribute)'
     ],
 
@@ -109,6 +109,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this._userActivate(!this.active);
       } else {
         this.active = false;
+      }
+    },
+
+    _focusChanged: function(focused) {
+      this._detectKeyboardFocus(focused);
+
+      if (!focused) {
+        this._setPressed(false);
       }
     },
 

--- a/test/active-state.html
+++ b/test/active-state.html
@@ -125,6 +125,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             });
           });
         });
+
+        suite('on blur', function() {
+          test('the pressed property becomes false', function() {
+            MockInteractions.focus(activeTarget);
+            MockInteractions.down(activeTarget);
+            expect(activeTarget.hasAttribute('pressed')).to.be.eql(true);
+            MockInteractions.blur(activeTarget);
+            expect(activeTarget.hasAttribute('pressed')).to.be.eql(false);
+          });
+        });
       });
 
       suite('without toggles attribute', function() {


### PR DESCRIPTION
This is an upstream change required for PolymerElements/paper-button#135. In addition to doing the ripple up action (to be addressed in PaperButtonBehavior), we should also clear the pressed state if the user tabs out of the button, which this PR addresses.
