### PR TITLE
from polymerelements to PolymerElements in 2.0-preview

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -32,13 +32,13 @@
     "1.x": {
       "dependencies": {
         "polymer": "Polymer/polymer#^1.1.0",
-        "iron-a11y-keys-behavior": "polymerelements/iron-a11y-keys-behavior#^1.0.0"
+        "iron-a11y-keys-behavior": "PolymerElements/iron-a11y-keys-behavior#^1.0.0"
       },
       "devDependencies": {
-        "paper-styles": "polymerelements/paper-styles#^1.0.0",
-        "paper-input": "polymerelements/paper-input#^1.0.0",
-        "iron-test-helpers": "polymerelements/iron-test-helpers#^1.0.0",
-        "iron-component-page": "polymerelements/iron-component-page#^1.0.0",
+        "paper-styles": "PolymerElements/paper-styles#^1.0.0",
+        "paper-input": "PolymerElements/paper-input#^1.0.0",
+        "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.0.0",
+        "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
         "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
         "web-component-tester": "Polymer/web-component-tester#^4.0.0"
       }

--- a/bower.json
+++ b/bower.json
@@ -16,14 +16,14 @@
   ],
   "license": "http://polymer.github.io/LICENSE.txt",
   "dependencies": {
-    "polymer": "polymer/polymer#^2.0.0-rc.1",
-    "iron-a11y-keys-behavior": "polymerelements/iron-a11y-keys-behavior#2.0-preview"
+    "polymer": "Polymer/polymer#^2.0.0-rc.1",
+    "iron-a11y-keys-behavior": "PolymerElements/iron-a11y-keys-behavior#2.0-preview"
   },
   "devDependencies": {
-    "paper-styles": "polymerelements/paper-styles#2.0-preview",
-    "paper-input": "polymerelements/paper-input#2.0-preview",
-    "iron-test-helpers": "polymerelements/iron-test-helpers#2.0-preview",
-    "iron-component-page": "polymerelements/iron-component-page#2.0-preview",
+    "paper-styles": "PolymerElements/paper-styles#2.0-preview",
+    "paper-input": "PolymerElements/paper-input#2.0-preview",
+    "iron-test-helpers": "PolymerElements/iron-test-helpers#2.0-preview",
+    "iron-component-page": "PolymerElements/iron-component-page#2.0-preview",
     "web-component-tester": "Polymer/web-component-tester#^6.0.0-prerelease.6",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0-rc.1"
   },


### PR DESCRIPTION
This pull request wanta to make this Polymer element consistent with the majority of other Polymer elements in the 2.0-preview branch. The uppercase version "PolymerElements" and "Polymer" is closer to real name of the github project name, like presented in the git URL.

The use of mixed case does not seem to have an effect on bower and JavaScript projects. But other languages like Java are more picky and would benefit from consistency.

I fixed this in the  "2.0-preview" branch of this element, because it would be very nice to have this cleaned up and consistent in 2.0 release. I have manually checked 66 elements that have a "2.0-preview" branch. 56 are ok. This element is one of 10 which has these small differences

I'm mostly concerned with the bower "Main" dependencies, but as I have changed this file already I also fixed this in the devDependencies

This pull request is a manual follow up of PolymerLabs/tedium#47 and PolymerLabs/tedium#48 which try to do this in an automated way, but are stuck.