### PR TITLE
from polymerelements to PolymerElements (again)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,13 +17,13 @@
   "license": "http://polymer.github.io/LICENSE.txt",
   "dependencies": {
     "polymer": "Polymer/polymer#1.9 - 2",
-    "iron-a11y-keys-behavior": "polymerelements/iron-a11y-keys-behavior#1 - 2"
+    "iron-a11y-keys-behavior": "PolymerElements/iron-a11y-keys-behavior#1 - 2"
   },
   "devDependencies": {
-    "paper-styles": "polymerelements/paper-styles#1 - 2",
-    "paper-input": "polymerelements/paper-input#1 - 2",
-    "iron-test-helpers": "polymerelements/iron-test-helpers#1 - 2",
-    "iron-component-page": "polymerelements/iron-component-page#1 - 2",
+    "paper-styles": "PolymerElements/paper-styles#1 - 2",
+    "paper-input": "PolymerElements/paper-input#1 - 2",
+    "iron-test-helpers": "PolymerElements/iron-test-helpers#1 - 2",
+    "iron-component-page": "PolymerElements/iron-component-page#1 - 2",
     "web-component-tester": "^6.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0"
   },
@@ -32,13 +32,13 @@
     "1.x": {
       "dependencies": {
         "polymer": "Polymer/polymer#^1.9",
-        "iron-a11y-keys-behavior": "polymerelements/iron-a11y-keys-behavior#^1.0.0"
+        "iron-a11y-keys-behavior": "PolymerElements/iron-a11y-keys-behavior#^1.0.0"
       },
       "devDependencies": {
-        "paper-styles": "polymerelements/paper-styles#^1.0.0",
-        "paper-input": "polymerelements/paper-input#^1.0.0",
-        "iron-test-helpers": "polymerelements/iron-test-helpers#^1.0.0",
-        "iron-component-page": "polymerelements/iron-component-page#^1.0.0",
+        "paper-styles": "PolymerElements/paper-styles#^1.0.0",
+        "paper-input": "PolymerElements/paper-input#^1.0.0",
+        "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.0.0",
+        "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
         "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
         "web-component-tester": "Polymer/web-component-tester#^4.0.0"
       },


### PR DESCRIPTION
This pull request is similar to #72 but is based on the current master branch rather then the old 2.0-preview

The rational for this change is:

This pull request wanta to make this Polymer element consistent with the majority of other Polymer elements. The uppercase version "PolymerElements" is closer to real name of the github project name, like presented in the git URL.

The use of mixed case does not seem to have an effect on bower and JavaScript projects. But other languages like Java are more picky and would benefit from consistency.

I'm mostly concerned with the bower "Main" dependencies, but as I have changed this file already I also fixed this in the devDependencies

This pull request is a manual follow up of PolymerLabs/tedium#47 and PolymerLabs/tedium#48 which try to do this in an automated way, but are stuck.