### PR TITLE
Revert "Handle tabindex correctly"

### DIFF
--- a/iron-control-state.html
+++ b/iron-control-state.html
@@ -100,22 +100,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this.setAttribute('aria-disabled', disabled ? 'true' : 'false');
       this.style.pointerEvents = disabled ? 'none' : '';
       if (disabled) {
-        // We need to read `tabindex` from the attribute. The `tabindex`
-        // property returns `-1` if there is no `tabindex` attribute. And the
-        // distinction is important when `disabled` is changed back to `false`.
-        this._oldTabIndex = this.getAttribute('tabindex');
+        this._oldTabIndex = this.tabIndex;
         this._setFocused(false);
         this.tabIndex = -1;
         this.blur();
-      } else {
-        if (this._oldTabIndex) {
-          this.tabIndex = this._oldTabIndex;
-        } else {
-          // If there was no `tabindex` attribute, we need to remove it.
-          // Leaving `tabindex="-1"` causes focusable elements in the shadow
-          // tree to be skipped in the tab order. 
-          this.removeAttribute('tabindex');
-        }
+      } else if (this._oldTabIndex !== undefined) {
+        this.tabIndex = this._oldTabIndex;
       }
     },
 

--- a/test/disabled-state.html
+++ b/test/disabled-state.html
@@ -30,12 +30,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
-  <test-fixture id="TabIndexDisabledState">
-    <template>
-      <test-control></test-control>
-    </template>
-  </test-fixture>
-
   <script>
     suite('disabled-state', function() {
       var disableTarget;
@@ -79,25 +73,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         test('adds `aria-disabled` to the target', function() {
           expect(disableTarget.getAttribute('aria-disabled')).to.be.eql('true');
-        });
-      });
-
-      suite('tabindex', function() {
-        setup(function() {
-          disableTarget = fixture('TabIndexDisabledState');
-        });
-
-        test('does not leave tabindex="-1" after toggling disabled', function() {
-          disableTarget.disabled = true;
-          disableTarget.disabled = false;
-          expect(disableTarget.hasAttribute('tabindex')).to.be.eql(false);
-        });
-
-        test('restores original tabindex after toggling disabled', function() {
-          disableTarget.tabIndex = '0';
-          disableTarget.disabled = true;
-          disableTarget.disabled = false;
-          expect(disableTarget.getAttribute('tabindex')).to.be.eql('0');
         });
       });
     });


### PR DESCRIPTION
Reverts PolymerElements/iron-behaviors#78

It broke `<paper-tabs>`.