### PR TITLE
fix retargetting focus

### DIFF
--- a/iron-control-state.html
+++ b/iron-control-state.html
@@ -76,7 +76,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _focusBlurHandler: function(event) {
       // In Polymer 2.0, the library takes care of retargeting events.
       if (Polymer.Element) {
-        this._setFocused(event.type === 'focus');
+        // 1.x / hybrid backwards compatiblity
+        if (event.target === this) {
+          this._setFocused(event.type === 'focus');
+        }
         return;
       }
 

--- a/test/focused-state.html
+++ b/test/focused-state.html
@@ -31,6 +31,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="SlottedFocusedState">
+    <template>
+      <slotted-focusable>
+        <input id="slotted">
+      </slotted-focusable>
+    </template>
+  </test-fixture>
+
   <test-fixture id="LightDOM">
     <template>
       <test-light-dom>
@@ -114,6 +122,28 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         expect(nBlurEvents).to.be.greaterThan(0);
         expect(nFocusEvents).to.be.greaterThan(0);
+      });
+    });
+
+    suite('slotted focusable', function() {
+      var focusable;
+      var shadow;
+      var slotted;
+
+      setup(function() {
+        focusable = fixture('SlottedFocusedState');
+        shadow = focusable.$.shadow;
+        slotted = focusable.querySelector('#slotted');
+      });
+
+      test('focus/blur of slotted does not focus/blur host element', function() {
+        expect(focusable.focused).to.be.equal(false);
+        MockInteractions.focus(slotted);
+        expect(focusable.focused).to.be.equal(false);
+        MockInteractions.focus(shadow);
+        expect(focusable.focused).to.be.equal(true);
+        MockInteractions.focus(slotted);
+        expect(focusable.focused).to.be.equal(true);
       });
     });
 

--- a/test/test-elements.html
+++ b/test/test-elements.html
@@ -54,6 +54,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   });
 </script>
 
+<dom-module id="slotted-focusable">
+
+  <template>
+    <input id="shadow">
+    <slot></slot>
+  </template>
+
+</dom-module>
+
+<script>
+  Polymer({
+
+    is: 'slotted-focusable',
+
+    behaviors: [Polymer.IronControlState]
+
+  });
+</script>
+
 <dom-module id="test-light-dom">
 
   <template>


### PR DESCRIPTION
focused is set differently than it is set in polymer 1.

Reproduction:
polymer 2:
https://www.webcomponents.org/element/PolymerElements/paper-input/demo/demo/index.html

scroll down to "Inputs can have prefixes and suffixes" and try to tab through all the fields

polymer 1:
https://www.webcomponents.org/element/PolymerElements/paper-input/v1.1.24/demo/demo/index.html

scroll down to "Inputs can have prefixes and suffixes" and try to tab through all the fields

This makes i-c-s have the functionality of polymer 1.