### PR TITLE
Fix `receivedFocusFromKeyboard` on touch devices.

### DIFF
--- a/iron-button-state.js
+++ b/iron-button-state.js
@@ -69,7 +69,7 @@ export const IronButtonStateImpl = {
     }
   },
 
-  listeners: {down: '_downHandler', up: '_upHandler', tap: '_tapHandler'},
+  listeners: {down: '_downHandler', mouseup: '_upHandler', tap: '_tapHandler'},
 
   observers:
       ['_focusChanged(focused)', '_activeChanged(active, ariaActiveAttribute)'],


### PR DESCRIPTION
The 'down' and 'up' listeners both fire before 'focus' when the element is focused by a touch event, which prevents IronButtonState from knowing that focus changed due to touch. This changes the 'up' listener to 'mouseup', which consistently occurs after 'focus' on both desktop and touch.